### PR TITLE
Added R16B compatibility and missing dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,19 @@ First time installation instructions:
    exist.
 3. Run `./rebar compile` - this will compile all dependencies and the main
    applications.
-4. Find and open CouchDB's local config file, usually at /etc/couchdb/local.ini.
-5. Within the `[httpd]` section, add a line `bind_address = 0.0.0.0` in order to
+4. There are some cases where `jiffy` won't compile its C source code when
+   running `rebar compile`. To remedy that, go to `deps/jiffy` and run an extra
+   `./rebar compile` from there. This will fix errors about `jiffy.so` not being
+   found.
+5. Find and open CouchDB's local config file, usually at /etc/couchdb/local.ini.
+6. Within the `[httpd]` section, add a line `bind_address = 0.0.0.0` in order to
    allow access from the internet (required if you want to expose the built-in
    web frontend to your users). Also make sure port 5984 can be reached. If you
    installed CouchDB from source, you have to allow write access to that ini
    file from CouchDB's process.
-5. Start CouchDB and browse to its local web frontend at
+7. Start CouchDB and browse to its local web frontend at
    `http://<your domain>:5984/_utils/`
-6. On the lower right corner it'll say "Welcome to Admin Party!".
+8. On the lower right corner it'll say "Welcome to Admin Party!".
    Click "Fix this" and create an admin account for ecoinpool with a password of
    your choice. Note it down for later. Optionally create another admin account
    for yourself.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ coin pool software, yet not everything is 100% solid and waterproof and some
 features are missing in this version. Nevertheless, everything you need to get
 started and give it a try is there.
 
-ecoinpool supports Bitcoin, Bitcoin+Namecoin (merged), Litecoin and Fairbrix.
+ecoinpool supports Bitcoin, Bitcoin+Namecoin (merged), Litecoin.
 
 Contact
 -------

--- a/apps/ebitcoin/include/btc_protocol_records.hrl
+++ b/apps/ebitcoin/include/btc_protocol_records.hrl
@@ -47,7 +47,8 @@
     version = 1 :: integer(),
     tx_in :: [btc_tx_in()],
     tx_out :: [btc_tx_out()],
-    lock_time = 0 :: integer()
+    lock_time = 0 :: integer(),
+    ref_height = 0 :: integer()
 }).
 -type btc_tx() :: #btc_tx{}.
 

--- a/apps/ebitcoin/src/ebitcoin_chain_data.erl
+++ b/apps/ebitcoin/src/ebitcoin_chain_data.erl
@@ -34,7 +34,6 @@ type_and_port(<<"nmc">>) -> {namecoin, 8334};
 type_and_port(<<"nmc_testnet">>) -> {namecoin_testnet, 18334};
 type_and_port(<<"ltc">>) -> {litecoin, 9333};
 type_and_port(<<"ltc_testnet">>) -> {litecoin_testnet, 19333};
-type_and_port(<<"fbx">>) -> {fairbrix, 8591};
 
 type_and_port(_) -> undefined.
 
@@ -49,9 +48,7 @@ network_magic(namecoin_testnet) ->
 network_magic(litecoin) ->
     <<251,192,182,219>>;
 network_magic(litecoin_testnet) ->
-    <<252,193,183,220>>;
-network_magic(fairbrix) ->
-    <<249,219,249,219>>.
+    <<252,193,183,220>>.
 
 genesis_block(bitcoin) ->
     ZeroHash = binary:list_to_bin(lists:duplicate(32,0)),
@@ -133,30 +130,3 @@ genesis_block(litecoin) ->
     },
     BlockHash = <<"12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2">>,
     {BlockHash, Header, Tx};
-
-genesis_block(fairbrix) ->
-    ZeroHash = binary:list_to_bin(lists:duplicate(32,0)),
-    Header = #btc_header{
-        version = 1,
-        hash_prev_block = ZeroHash,
-        hash_merkle_root = base64:decode(<<"QKYnJi7XFvDz1RBDFf4LYAv44yoCGSkpkWP3QVH6UrE=">>),
-        timestamp = 16#4e87e916,
-        bits = 16#1e0ffff0,
-        nonce = 16#16fbf1ed
-    },
-    Tx = #btc_tx{
-        version = 1,
-        tx_in = [#btc_tx_in{
-            prev_output_hash = ZeroHash,
-            prev_output_index = 16#ffffffff,
-            signature_script = [16#1d00ffff, <<4>>, <<"\"nytimes.com 10/1/2011 - Police Arrest Over 700 Protesters on Brooklyn Bridge\"">>],
-            sequence = 16#ffffffff
-        }],
-        tx_out = [#btc_tx_out{
-            value = 5000000000,
-            pk_script = base64:decode(<<"QQRniv2w/lVIJxln8aZxMLcQXNaoKOA5CaZ5YuDqH2Hetkn2vD9M7zjE81UE5R7BEt5cOE33uguNV4pMcCtr8R1frA==">>)
-        }],
-        lock_time = 0
-    },
-    BlockHash = <<"002a91713910bc96eb0edf237fcd2799d7a01186e1e96023e860bc70b3916200">>,
-    {BlockHash, Header, Tx}.

--- a/apps/ebitcoin/src/ebitcoin_chain_data.erl
+++ b/apps/ebitcoin/src/ebitcoin_chain_data.erl
@@ -144,10 +144,10 @@ genesis_block(freicoin) ->
     Header = #btc_header{
         version = 1,
         hash_prev_block = ZeroHash,
-        hash_merkle_root = base64:decode(<<"JmMhIlkSHyjHT9C0Rg+PTyrcoEjm8WZmbA0OmRbg4bY=">>),
-        timestamp = 16#5004dd1d,
+        hash_merkle_root = base64:decode(<<"tgN4/8leZxiafMA6JQwtK5IyLyLQY/Ya1KexQ5+r5D8=">>),
+        timestamp = 16#50536290,
         bits = 16#1d00ffff,
-        nonce = 16#340cafbb
+        nonce = 16#37fc17e7
     },
     Tx = #btc_tx{
         version = 2,
@@ -158,11 +158,11 @@ genesis_block(freicoin) ->
             sequence = 16#ffffffff
         }],
         tx_out = [#btc_tx_out{
-            value = 2380952380962,
+            value = 7950387546951,
             pk_script = base64:decode(<<"QQRniv2w/lVIJxln8aZxMLcQXNaoKOA5CaZ5YuDqH2Hetkn2vD9M7zjE81UE5R7BEt5cOE33uguNV4pMcCtr8R1frA==">>)
         }],
         lock_time = 0,
         ref_height = 0
     },
-    BlockHash = <<"00000000f0918a8aeb7d5d613c709e862fdf01b7e2604616af1b6194e3c77694">>,
+    BlockHash = <<"000000000c29f26697c30e29039927ab4241b5fc2cc76db7e0dafa5e2612ad46">>,
     {BlockHash, Header, Tx}.

--- a/apps/ebitcoin/src/ebitcoin_chain_data.erl
+++ b/apps/ebitcoin/src/ebitcoin_chain_data.erl
@@ -34,7 +34,8 @@ type_and_port(<<"nmc">>) -> {namecoin, 8334};
 type_and_port(<<"nmc_testnet">>) -> {namecoin_testnet, 18334};
 type_and_port(<<"ltc">>) -> {litecoin, 9333};
 type_and_port(<<"ltc_testnet">>) -> {litecoin_testnet, 19333};
-type_and_port(<<"fbx">>) -> {fairbrix, 8591};
+type_and_port(<<"frc">>) -> {freicoin, 8639};
+type_and_port(<<"frc_testnet">>) -> {freicoin_testnet, 18639};
 
 type_and_port(_) -> undefined.
 
@@ -50,8 +51,12 @@ network_magic(litecoin) ->
     <<251,192,182,219>>;
 network_magic(litecoin_testnet) ->
     <<252,193,183,220>>;
-network_magic(fairbrix) ->
-    <<249,219,249,219>>.
+network_magic(freicoin) ->
+    <<199,211,35,137>>;
+network_magic(freicoin_testnet) ->
+    <<200,212,36,138>>;
+
+network_magic(_) -> undefined.
 
 genesis_block(bitcoin) ->
     ZeroHash = binary:list_to_bin(lists:duplicate(32,0)),
@@ -134,29 +139,30 @@ genesis_block(litecoin) ->
     BlockHash = <<"12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2">>,
     {BlockHash, Header, Tx};
 
-genesis_block(fairbrix) ->
+genesis_block(freicoin) ->
     ZeroHash = binary:list_to_bin(lists:duplicate(32,0)),
     Header = #btc_header{
         version = 1,
         hash_prev_block = ZeroHash,
-        hash_merkle_root = base64:decode(<<"QKYnJi7XFvDz1RBDFf4LYAv44yoCGSkpkWP3QVH6UrE=">>),
-        timestamp = 16#4e87e916,
-        bits = 16#1e0ffff0,
-        nonce = 16#16fbf1ed
+        hash_merkle_root = base64:decode(<<"tgN4/8leZxiafMA6JQwtK5IyLyLQY/Ya1KexQ5+r5D8=">>),
+        timestamp = 16#50536290,
+        bits = 16#1d00ffff,
+        nonce = 16#37fc17e7
     },
     Tx = #btc_tx{
-        version = 1,
+        version = 2,
         tx_in = [#btc_tx_in{
             prev_output_hash = ZeroHash,
             prev_output_index = 16#ffffffff,
-            signature_script = [16#1d00ffff, <<4>>, <<"\"nytimes.com 10/1/2011 - Police Arrest Over 700 Protesters on Brooklyn Bridge\"">>],
+            signature_script = [16#1d00ffff, <<4>>, <<"Telegraph 27/Jun/2012 Barclays hit with ", 194, 163, "290m fine over Libor fixing">>],
             sequence = 16#ffffffff
         }],
         tx_out = [#btc_tx_out{
-            value = 5000000000,
+            value = 7950387546951,
             pk_script = base64:decode(<<"QQRniv2w/lVIJxln8aZxMLcQXNaoKOA5CaZ5YuDqH2Hetkn2vD9M7zjE81UE5R7BEt5cOE33uguNV4pMcCtr8R1frA==">>)
         }],
-        lock_time = 0
+        lock_time = 0,
+        ref_height = 0
     },
-    BlockHash = <<"002a91713910bc96eb0edf237fcd2799d7a01186e1e96023e860bc70b3916200">>,
+    BlockHash = <<"000000000c29f26697c30e29039927ab4241b5fc2cc76db7e0dafa5e2612ad46">>,
     {BlockHash, Header, Tx}.

--- a/apps/ebitcoin/src/ebitcoin_chain_data.erl
+++ b/apps/ebitcoin/src/ebitcoin_chain_data.erl
@@ -34,6 +34,8 @@ type_and_port(<<"nmc">>) -> {namecoin, 8334};
 type_and_port(<<"nmc_testnet">>) -> {namecoin_testnet, 18334};
 type_and_port(<<"ltc">>) -> {litecoin, 9333};
 type_and_port(<<"ltc_testnet">>) -> {litecoin_testnet, 19333};
+type_and_port(<<"frc">>) -> {freicoin, 8639};
+type_and_port(<<"frc_testnet">>) -> {freicoin_testnet, 18639};
 
 type_and_port(_) -> undefined.
 
@@ -48,7 +50,13 @@ network_magic(namecoin_testnet) ->
 network_magic(litecoin) ->
     <<251,192,182,219>>;
 network_magic(litecoin_testnet) ->
-    <<252,193,183,220>>.
+    <<252,193,183,220>>;
+network_magic(freicoin) ->
+    <<199,211,35,137>>;
+network_magic(freicoin_testnet) ->
+    <<200,212,36,138>>;
+
+network_magic(_) -> undefined.
 
 genesis_block(bitcoin) ->
     ZeroHash = binary:list_to_bin(lists:duplicate(32,0)),
@@ -130,3 +138,31 @@ genesis_block(litecoin) ->
     },
     BlockHash = <<"12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2">>,
     {BlockHash, Header, Tx};
+
+genesis_block(freicoin) ->
+    ZeroHash = binary:list_to_bin(lists:duplicate(32,0)),
+    Header = #btc_header{
+        version = 1,
+        hash_prev_block = ZeroHash,
+        hash_merkle_root = base64:decode(<<"JmMhIlkSHyjHT9C0Rg+PTyrcoEjm8WZmbA0OmRbg4bY=">>),
+        timestamp = 16#5004dd1d,
+        bits = 16#1d00ffff,
+        nonce = 16#340cafbb
+    },
+    Tx = #btc_tx{
+        version = 2,
+        tx_in = [#btc_tx_in{
+            prev_output_hash = ZeroHash,
+            prev_output_index = 16#ffffffff,
+            signature_script = [16#1d00ffff, <<4>>, <<"Telegraph 27/Jun/2012 Barclays hit with ", 194, 163, "290m fine over Libor fixing">>],
+            sequence = 16#ffffffff
+        }],
+        tx_out = [#btc_tx_out{
+            value = 2380952380962,
+            pk_script = base64:decode(<<"QQRniv2w/lVIJxln8aZxMLcQXNaoKOA5CaZ5YuDqH2Hetkn2vD9M7zjE81UE5R7BEt5cOE33uguNV4pMcCtr8R1frA==">>)
+        }],
+        lock_time = 0,
+        ref_height = 0
+    },
+    BlockHash = <<"00000000f0918a8aeb7d5d613c709e862fdf01b7e2604616af1b6194e3c77694">>,
+    {BlockHash, Header, Tx}.

--- a/apps/ecoinpool/rebar.config
+++ b/apps/ecoinpool/rebar.config
@@ -23,7 +23,7 @@
 {lib_dirs, [".."]}.
 
 {port_sources, [
-    {"R14|R15", ["c_src/*.c", "c_src/*.S"]}
+    {"R14|R15|R16", ["c_src/*.c", "c_src/*.S"]}
 ]}.
 
 {so_specs, [

--- a/apps/ecoinpool/src/abstract_coindaemon.erl
+++ b/apps/ecoinpool/src/abstract_coindaemon.erl
@@ -23,6 +23,8 @@
 
 % Instances of this module are returned by ecoinpool_server_sup:start_coindaemon/3
 
+-include_lib("pmod_transform/include/pmod.hrl").
+
 -module(abstract_coindaemon, [M, PID]).
 
 -export([

--- a/apps/ecoinpool/src/btc_coindaemon.erl
+++ b/apps/ecoinpool/src/btc_coindaemon.erl
@@ -104,7 +104,7 @@ post_workunit(PID) ->
     gen_server:cast(PID, post_workunit).
 
 send_result(PID, BData) ->
-    gen_server:call(PID, {send_result, BData}).
+    gen_server:call(PID, {send_result, BData}, 30000).
 
 get_first_tx_with_branches(PID, Workunit) ->
     gen_server:call(PID, {get_first_tx_with_branches, Workunit}).

--- a/apps/ecoinpool/src/btc_daemon_util.erl
+++ b/apps/ecoinpool/src/btc_daemon_util.erl
@@ -217,7 +217,7 @@ get_default_payout_address(URL, Auth) ->
     end.
 
 get_block_number(URL, Auth) ->
-    {ok, "200", _ResponseHeaders, ResponseBody} = ecoinpool_util:send_http_req(URL, Auth, "{\"method\":\"getblocknumber\"}"),
+    {ok, "200", _ResponseHeaders, ResponseBody} = ecoinpool_util:send_http_req(URL, Auth, "{\"method\":\"getblockcount\"}"),
     {Body} = ejson:decode(ResponseBody),
     proplists:get_value(<<"result">>, Body) + 1.
 

--- a/apps/ecoinpool/src/ecoinpool_db.erl
+++ b/apps/ecoinpool/src/ecoinpool_db.erl
@@ -321,8 +321,6 @@ parse_subpool_document({DocProps}) ->
     PoolType = case proplists:get_value(<<"pool_type">>, DocProps) of
         <<"btc">> -> btc;
         <<"ltc">> -> ltc;
-        <<"fbx">> -> fbx;
-        <<"sc">> -> sc;
         _ -> undefined
     end,
     MaxCacheSize = proplists:get_value(<<"max_cache_size">>, DocProps, 20),

--- a/apps/ecoinpool/src/ecoinpool_mmm.erl
+++ b/apps/ecoinpool/src/ecoinpool_mmm.erl
@@ -26,6 +26,8 @@
 % Instances of this module are returned by ecoinpool_server_sup:add_auxdaemon/4
 % and ecoinpool_server_sup:remove_auxdaemon/3
 
+-include_lib("pmod_transform/include/pmod.hrl").
+
 -module(ecoinpool_mmm, [AuxDaemons]).
 
 -include("../ebitcoin/include/btc_protocol_records.hrl").

--- a/apps/ecoinpool/src/ecoinpool_rpc_request.erl
+++ b/apps/ecoinpool/src/ecoinpool_rpc_request.erl
@@ -18,6 +18,8 @@
 %% along with ecoinpool.  If not, see <http://www.gnu.org/licenses/>.
 %%
 
+-include_lib("pmod_transform/include/pmod.hrl").
+
 -module(ecoinpool_rpc_request, [ReqPID, Peer, Method, Params, Auth, MiningExtensions, LP]).
 
 -export([get/1, has_params/0, check/0, start/2, ok/2, error/1]).

--- a/apps/ecoinpool/src/ecoinpool_server.erl
+++ b/apps/ecoinpool/src/ecoinpool_server.erl
@@ -150,8 +150,7 @@ handle_cast({reload_config, Subpool}, State=#state{subpool=OldSubpool, workq_siz
     #subpool{port=OldPort, max_cache_size=OldMaxCacheSize, lowercase_workers=OldLowercaseWorkers, worker_share_subpools=OldWorkerShareSubpools, coin_daemon_config=OldCoinDaemonConfig, aux_pool=OldAuxpool} = OldSubpool,
     % Derive the CoinDaemon module name from PoolType + "_coindaemon", except for SCrypt pools which are all handled by scrypt_coindaemon
     CoinDaemonModule = if
-        PoolType =:= ltc;
-        PoolType =:= fbx ->
+        PoolType =:= ltc ->
             scrypt_coindaemon;
         true ->
             list_to_atom(lists:concat([PoolType, "_coindaemon"]))

--- a/apps/ecoinpool/src/scrypt_coindaemon.erl
+++ b/apps/ecoinpool/src/scrypt_coindaemon.erl
@@ -118,8 +118,7 @@ init([SubpoolId, Config]) ->
     log4erl:warn(daemon, "SCrypt-~p CoinDaemon starting...", [PoolType]),
     
     DefaultPort = case PoolType of
-        ltc -> 9332;
-        fbx -> 8645
+        ltc -> 9332
     end,
     {URL, Auth, CoinbaserConfig, FullTag, EBtcId} = btc_daemon_util:parse_config(Config, DefaultPort),
     

--- a/extras/ecoinpool.php
+++ b/extras/ecoinpool.php
@@ -558,9 +558,7 @@ class EcoinpoolSubPool
     public function hashspeedFromSharespeed($shares_per_second)
     {
         switch ($this->pool_type) {
-            case "sc":
             case "ltc":
-            case "fbx":
                 return $shares_per_second * 131072;
             default:
                 return $shares_per_second * 4294967296;

--- a/rebar.config
+++ b/rebar.config
@@ -23,16 +23,16 @@
 {sub_dirs, ["apps/ecoinpool", "apps/ebitcoin", "rel"]}.
 
 {deps, [
-    {protobuffs, ".*", {git, "git://github.com/basho/erlang_protobuffs.git", "master"}},
-    {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git", "master"}},
-    {log4erl, ".*", {git, "git://github.com/SemanticSugar/log4erl.git", "master"}},
-    {mysql, ".*", {git, "git://github.com/elbrujohalcon/erlang-mysql-driver.git", "master"}},
-    {epgsql, ".*", {git, "git://github.com/wg/epgsql.git", "master"}},
-
-    % Licensed under Apache 2.0; (http://www.apache.org/licenses/GPL-compatibility.html)
-    {ejson, ".*", {git, "git://github.com/benoitc/ejson.git", "master"}},
-
-    {pmod_transform, ".*", {git, "git://github.com/erlang/pmod_transform.git", "master"}} % R16B+ Compat
+    {pmod_transform, ".*", {git, "git://github.com/erlang/pmod_transform.git", "b59924eb82122ccb0168ccd1757dde408d2df3c4"}}, % R16B+ Compat
+    {protobuffs, ".*", {git, "git://github.com/basho/erlang_protobuffs.git", "e0f5f6ea4c3dcb4e7b824496d2b48333fbd5a8c8"}},
+    {ejson, ".*", {git, "git://github.com/benoitc/ejson.git", "820ff1725008e664293b88e13c16193857afc072"}},
+    {oauth, ".*", {git, "git://github.com/refuge/erlang-oauth.git", "f332b77371d334d0faa13e106d0c36f948b325b6"}},
+    {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git", "eb8b62cf84ccae141700c8fd251277df8be27f28"}},
+    {mochiweb, ".*", {git, "git://github.com/mochi/mochiweb.git", "b7f3693a9008de6d31a67174f7184fe24093a1b4"}},
+    {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git", "7148bbdb19aca91b7b74e5392a23c94d33ca4e27"}},
+    {log4erl, ".*", {git, "git://github.com/SemanticSugar/log4erl.git", "ec580f75ef9e28dfcfac92dc0d42c435520bd3d7"}},
+    {mysql, ".*", {git, "git://github.com/elbrujohalcon/erlang-mysql-driver.git", "1dd4e22a80546fa1bda81607d6397a549fd791ae"}},
+    {epgsql, ".*", {git, "git://github.com/wg/epgsql.git", "fc434772276475ac4e5b0bed6b18ed4732502156"}}
 ]}.
 
 {erl_opts, [fail_on_warning, debug_info, warn_unused_vars, warn_unused_import, warn_exported_vars]}.

--- a/rebar.config
+++ b/rebar.config
@@ -23,11 +23,15 @@
 {sub_dirs, ["apps/ecoinpool", "apps/ebitcoin", "rel"]}.
 
 {deps, [
-    {protobuffs, ".*", {git, "git://github.com/basho/erlang_protobuffs.git", "master"}},
-    {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git", "master"}},
-    {log4erl, ".*", {git, "git://github.com/SemanticSugar/log4erl.git", "master"}},
-    {mysql, ".*", {git, "git://github.com/elbrujohalcon/erlang-mysql-driver.git", "master"}},
-    {epgsql, ".*", {git, "git://github.com/wg/epgsql.git", "master"}}
+    {protobuffs, ".*", {git, "git://github.com/basho/erlang_protobuffs.git", "e0f5f6ea4c3dcb4e7b824496d2b48333fbd5a8c8"}},
+    {ejson, ".*", {git, "git://github.com/benoitc/ejson.git", "820ff1725008e664293b88e13c16193857afc072"}},
+    {oauth, ".*", {git, "git://github.com/refuge/erlang-oauth.git", "f332b77371d334d0faa13e106d0c36f948b325b6"}},
+    {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git", "eb8b62cf84ccae141700c8fd251277df8be27f28"}},
+    {mochiweb, ".*", {git, "git://github.com/mochi/mochiweb.git", "b7f3693a9008de6d31a67174f7184fe24093a1b4"}},
+    {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git", "7148bbdb19aca91b7b74e5392a23c94d33ca4e27"}},
+    {log4erl, ".*", {git, "git://github.com/SemanticSugar/log4erl.git", "ec580f75ef9e28dfcfac92dc0d42c435520bd3d7"}},
+    {mysql, ".*", {git, "git://github.com/elbrujohalcon/erlang-mysql-driver.git", "1dd4e22a80546fa1bda81607d6397a549fd791ae"}},
+    {epgsql, ".*", {git, "git://github.com/wg/epgsql.git", "fc434772276475ac4e5b0bed6b18ed4732502156"}}
 ]}.
 
 {erl_opts, [fail_on_warning, debug_info, warn_unused_vars, warn_unused_import, warn_exported_vars]}.

--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
     {ejson, ".*", {git, "git://github.com/benoitc/ejson.git", "820ff1725008e664293b88e13c16193857afc072"}},
     {oauth, ".*", {git, "git://github.com/refuge/erlang-oauth.git", "f332b77371d334d0faa13e106d0c36f948b325b6"}},
     {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse.git", "eb8b62cf84ccae141700c8fd251277df8be27f28"}},
-    {mochiweb, ".*", {git, "git://github.com/mochi/mochiweb.git", "b7f3693a9008de6d31a67174f7184fe24093a1b4"}},
+    {mochiweb, ".*", {git, "git://github.com/mochi/mochiweb.git", "31efc6003d40a5b4a4f8544c545ca74f0d722228"}},
     {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git", "7148bbdb19aca91b7b74e5392a23c94d33ca4e27"}},
     {log4erl, ".*", {git, "git://github.com/SemanticSugar/log4erl.git", "ec580f75ef9e28dfcfac92dc0d42c435520bd3d7"}},
     {mysql, ".*", {git, "git://github.com/elbrujohalcon/erlang-mysql-driver.git", "1dd4e22a80546fa1bda81607d6397a549fd791ae"}},

--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,12 @@
     {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git", "master"}},
     {log4erl, ".*", {git, "git://github.com/SemanticSugar/log4erl.git", "master"}},
     {mysql, ".*", {git, "git://github.com/elbrujohalcon/erlang-mysql-driver.git", "master"}},
-    {epgsql, ".*", {git, "git://github.com/wg/epgsql.git", "master"}}
+    {epgsql, ".*", {git, "git://github.com/wg/epgsql.git", "master"}},
+
+    % Licensed under Apache 2.0; (http://www.apache.org/licenses/GPL-compatibility.html)
+    {ejson, ".*", {git, "git://github.com/benoitc/ejson.git", "master"}},
+
+    {pmod_transform, ".*", {git, "git://github.com/erlang/pmod_transform.git", "master"}} % R16B+ Compat
 ]}.
 
 {erl_opts, [fail_on_warning, debug_info, warn_unused_vars, warn_unused_import, warn_exported_vars]}.

--- a/site/src/common.js
+++ b/site/src/common.js
@@ -482,6 +482,18 @@ var poolTypeInfo = new (function PoolTypeInfo () {
     };
     
     addType({
+        type: "frc",
+        title: "Freicoin",
+        hps: 4295032833,
+        cb: true,
+        ebc: true,
+        rpc: 8638,
+        p2p: 8639,
+        aux: [],
+        auxonly: false
+    });
+    
+    addType({
         type: "btc",
         title: "BitCoin",
         hps: 4295032833,

--- a/site/src/common.js
+++ b/site/src/common.js
@@ -516,18 +516,6 @@ var poolTypeInfo = new (function PoolTypeInfo () {
         aux: [],
         auxonly: false
     });
-    
-    addType({
-        type: "fbx",
-        title: "FairBrix",
-        hps: 131072,
-        cb: true,
-        ebc: true,
-        rpc: 8645,
-        p2p: 8591,
-        aux: [],
-        auxonly: false
-    });
 });
 
 var templates = {};

--- a/site/src/common.js
+++ b/site/src/common.js
@@ -495,7 +495,7 @@ var poolTypeInfo = new (function PoolTypeInfo () {
     
     addType({
         type: "btc",
-        title: "BitCoin",
+        title: "Bitcoin",
         hps: 4295032833,
         cb: true,
         ebc: true,
@@ -507,7 +507,7 @@ var poolTypeInfo = new (function PoolTypeInfo () {
     
     addType({
         type: "nmc",
-        title: "NameCoin",
+        title: "Namecoin",
         hps: 4295032833,
         cb: false,
         ebc: true,
@@ -519,7 +519,7 @@ var poolTypeInfo = new (function PoolTypeInfo () {
     
     addType({
         type: "ltc",
-        title: "LiteCoin",
+        title: "Litecoin",
         hps: 131072,
         cb: true,
         ebc: true,

--- a/site/src/common.js
+++ b/site/src/common.js
@@ -482,8 +482,20 @@ var poolTypeInfo = new (function PoolTypeInfo () {
     };
     
     addType({
+        type: "frc",
+        title: "Freicoin",
+        hps: 4295032833,
+        cb: true,
+        ebc: true,
+        rpc: 8638,
+        p2p: 8639,
+        aux: [],
+        auxonly: false
+    });
+    
+    addType({
         type: "btc",
-        title: "BitCoin",
+        title: "Bitcoin",
         hps: 4295032833,
         cb: true,
         ebc: true,
@@ -495,7 +507,7 @@ var poolTypeInfo = new (function PoolTypeInfo () {
     
     addType({
         type: "nmc",
-        title: "NameCoin",
+        title: "Namecoin",
         hps: 4295032833,
         cb: false,
         ebc: true,
@@ -507,24 +519,12 @@ var poolTypeInfo = new (function PoolTypeInfo () {
     
     addType({
         type: "ltc",
-        title: "LiteCoin",
+        title: "Litecoin",
         hps: 131072,
         cb: true,
         ebc: true,
         rpc: 9332,
         p2p: 9333,
-        aux: [],
-        auxonly: false
-    });
-    
-    addType({
-        type: "fbx",
-        title: "FairBrix",
-        hps: 131072,
-        cb: true,
-        ebc: true,
-        rpc: 8645,
-        p2p: 8591,
         aux: [],
         auxonly: false
     });


### PR DESCRIPTION
While installing on Arch Linux, I ran into a lot of issues. This pull requests fixes most of them , hopefully without breaking backward compatibility.
- The C source for `ecoinpool_hash.so` wasn't being compiled when running Erlang R16B. I added that version of Erlang to the version check.
- The C source for `jiffy.so` wasn't building. Since this is a dependency, I updated the README to explain that manually compiling jiffy might be required.
- `ejson` Wasn't part of the dependencies and caused ecoinpool to crash at runtime. I have updated the dependencies to get @benoitc 's version of `ejson`. It is licensed under Apache 2.0 and is thus valid in this project. (See the link in `rebar.config` for compatibility notice.)
- `OTP R16B` deprecates parameterized modules. Ericsson provides an open source module called `parse_transform` which will enable legacy code to run with parameterized module support. I have added that as a dependency and included it in the relevant `.erl` files. This module is supposed to work on older versions of Erlang, but I haven't tested, so you might be interested in trying it out before accepting the pull request.

I think this is pretty much everything.

Cheers
